### PR TITLE
fix(config): fix subdirectory loading failure

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -14,7 +14,8 @@ timezone: Asia/Shanghai
 # URL
 ## Set your site url here. For example, if you use GitHub Page, set url as 'https://username.github.io/project'
 # url: https://algo-x.cn
-url: https://limpidautumn.github.io/algox-archive/
+url: https://limpidautumn.github.io/algox-archive
+root: /algox-archive/
 permalink: articles/:title/
 permalink_defaults:
 pretty_urls:
@@ -101,10 +102,10 @@ theme: fluid
 
 # Deployment
 ## Docs: https://hexo.io/docs/one-command-deployment
-deploy:
-- type: git
-  repo: git@github.com:Taoran-01/Algo-X.git
-  branch: gh-pages
+# deploy:
+# - type: git
+#   repo: git@github.com:Taoran-01/Algo-X.git
+#   branch: gh-pages
 # - type: baidu_url_submitter
 
 sitemap:


### PR DESCRIPTION
The site's base URL had a trailing slash removed and a root path was explicitly set to `/algox-archive/`. This corrects resource resolution for pages served under a subdirectory, resolving the loading failure. The outdated deployment configuration was commented out.